### PR TITLE
Fixed union subquery processing

### DIFF
--- a/src/Tarantool/Query/Grammar.php
+++ b/src/Tarantool/Query/Grammar.php
@@ -138,4 +138,16 @@ class Grammar extends BaseGrammar
 
         return "insert into $table ($columns) values $parameters";
     }
+
+    /**
+     * overrides default wrapUnion function with removing parentheses on union subquery
+     * that is how tarantool union works
+     *
+     * @param  string  $sql
+     * @return string
+     */
+    protected function wrapUnion($sql)
+    {
+        return $sql;
+    }
 }


### PR DESCRIPTION
### overridden default query grammar wrapUnion function with removing parentheses on union subquery 
### that is how tarantool union works